### PR TITLE
fix: add PENDING and CANCELLING to non-terminal states in polling

### DIFF
--- a/.fern/metadata.json
+++ b/.fern/metadata.json
@@ -10,5 +10,5 @@
     "inline-file-properties": false,
     "inline-path-parameters": false
   },
-  "sdkVersion": "1.0.1"
+  "sdkVersion": "1.0.2"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ java {
 
 group = 'ai.extend'
 
-version = '1.0.1'
+version = '1.0.2'
 
 jar {
     dependsOn(":generatePomFileForMavenPublication")
@@ -81,7 +81,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'ai.extend'
             artifactId = 'extend-java-sdk'
-            version = '1.0.1'
+            version = '1.0.2'
             from components.java
             pom {
                 name = 'Extend.ai'

--- a/src/main/java/ai/extend/wrapper/resources/ClassifyRunsClient.java
+++ b/src/main/java/ai/extend/wrapper/resources/ClassifyRunsClient.java
@@ -27,6 +27,8 @@ public class ClassifyRunsClient extends ai.extend.resources.classifyruns.Classif
     static {
         NON_TERMINAL_STATUSES = new HashSet<ProcessorRunStatus>();
         NON_TERMINAL_STATUSES.add(ProcessorRunStatus.PROCESSING);
+        NON_TERMINAL_STATUSES.add(ProcessorRunStatus.valueOf("PENDING"));
+        NON_TERMINAL_STATUSES.add(ProcessorRunStatus.valueOf("CANCELLING"));
     }
 
     public ClassifyRunsClient(ClientOptions clientOptions) {

--- a/src/main/java/ai/extend/wrapper/resources/EditRunsClient.java
+++ b/src/main/java/ai/extend/wrapper/resources/EditRunsClient.java
@@ -27,6 +27,8 @@ public class EditRunsClient extends ai.extend.resources.editruns.EditRunsClient 
     static {
         NON_TERMINAL_STATUSES = new HashSet<EditRunStatus>();
         NON_TERMINAL_STATUSES.add(EditRunStatus.PROCESSING);
+        NON_TERMINAL_STATUSES.add(EditRunStatus.valueOf("PENDING"));
+        NON_TERMINAL_STATUSES.add(EditRunStatus.valueOf("CANCELLING"));
     }
 
     public EditRunsClient(ClientOptions clientOptions) {

--- a/src/main/java/ai/extend/wrapper/resources/ExtractRunsClient.java
+++ b/src/main/java/ai/extend/wrapper/resources/ExtractRunsClient.java
@@ -27,6 +27,8 @@ public class ExtractRunsClient extends ai.extend.resources.extractruns.ExtractRu
     static {
         NON_TERMINAL_STATUSES = new HashSet<ProcessorRunStatus>();
         NON_TERMINAL_STATUSES.add(ProcessorRunStatus.PROCESSING);
+        NON_TERMINAL_STATUSES.add(ProcessorRunStatus.valueOf("PENDING"));
+        NON_TERMINAL_STATUSES.add(ProcessorRunStatus.valueOf("CANCELLING"));
     }
 
     public ExtractRunsClient(ClientOptions clientOptions) {

--- a/src/main/java/ai/extend/wrapper/resources/ParseRunsClient.java
+++ b/src/main/java/ai/extend/wrapper/resources/ParseRunsClient.java
@@ -26,6 +26,8 @@ public class ParseRunsClient extends ai.extend.resources.parseruns.ParseRunsClie
     static {
         NON_TERMINAL_STATUSES = new HashSet<ParseRunStatusEnum>();
         NON_TERMINAL_STATUSES.add(ParseRunStatusEnum.PROCESSING);
+        NON_TERMINAL_STATUSES.add(ParseRunStatusEnum.valueOf("PENDING"));
+        NON_TERMINAL_STATUSES.add(ParseRunStatusEnum.valueOf("CANCELLING"));
     }
 
     public ParseRunsClient(ClientOptions clientOptions) {

--- a/src/main/java/ai/extend/wrapper/resources/SplitRunsClient.java
+++ b/src/main/java/ai/extend/wrapper/resources/SplitRunsClient.java
@@ -27,6 +27,8 @@ public class SplitRunsClient extends ai.extend.resources.splitruns.SplitRunsClie
     static {
         NON_TERMINAL_STATUSES = new HashSet<ProcessorRunStatus>();
         NON_TERMINAL_STATUSES.add(ProcessorRunStatus.PROCESSING);
+        NON_TERMINAL_STATUSES.add(ProcessorRunStatus.valueOf("PENDING"));
+        NON_TERMINAL_STATUSES.add(ProcessorRunStatus.valueOf("CANCELLING"));
     }
 
     public SplitRunsClient(ClientOptions clientOptions) {


### PR DESCRIPTION
## Summary

- The `NON_TERMINAL_STATUSES` sets for extract, classify, split, parse, and edit run clients only included `PROCESSING`, missing `PENDING` and `CANCELLING`
- This could cause `createAndPoll` to return prematurely if a run was in `PENDING` or `CANCELLING` state
- The workflow runs client already correctly included all three — this brings all other run types in line
- Matches the behavior of the Python SDK, which checks `PROCESSING`, `PENDING`, and `CANCELLING` across all run types

## Files changed

- `ExtractRunsClient.java` — added `PENDING`, `CANCELLING`
- `ClassifyRunsClient.java` — added `PENDING`, `CANCELLING`
- `SplitRunsClient.java` — added `PENDING`, `CANCELLING`
- `ParseRunsClient.java` — added `PENDING`, `CANCELLING`
- `EditRunsClient.java` — added `PENDING`, `CANCELLING`

## Test plan

- [ ] Verify `createAndPoll` does not return early when a run is in `PENDING` or `CANCELLING` state
- [ ] Verify existing polling behavior is unchanged for `PROCESSING` state
- [ ] Verify `valueOf("PENDING")` and `valueOf("CANCELLING")` correctly match deserialized status values via string-based equality

Made with [Cursor](https://cursor.com)