### PR TITLE
Rename ci.yml → publish.yml

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,6 +1,10 @@
 # Specify files that shouldn't be modified by Fern
 README.md
+
+# Publish workflow — customized with stricter error handling
+# Keep ci.yml listed so Fern doesn't regenerate it after the rename
 .github/workflows/ci.yml
+.github/workflows/publish.yml
 
 # Protect custom wrapper code
 src/main/java/ai/extend/wrapper/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: ci
+name: Build & Publish
 
 on: [push]
 


### PR DESCRIPTION
Rename the CI workflow file and update the workflow name to better reflect what it does:
- `ci.yml` → `publish.yml`
- Workflow name: `ci` → `Build & Publish`
- Updated `.fernignore` to protect both filenames so Fern doesn't regenerate the old one.

Made with [Cursor](https://cursor.com)