### PR TITLE
Enforce v prefix on release tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,8 +36,21 @@ jobs:
 
       - name: Test
         run: ./gradlew test
+
+  validate-tag:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require v prefix on tag
+        run: |
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          if [[ ! "$TAG_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::Tag '$TAG_NAME' is missing the required 'v' prefix (e.g. v1.7.0). Delete this release and recreate it with tag 'v$TAG_NAME'."
+            exit 1
+          fi
+
   publish:
-    needs: [compile, test]
+    needs: [compile, test, validate-tag]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
@@ -61,12 +74,6 @@ jobs:
 
           TAG_NAME="${GITHUB_REF#refs/tags/}"
           echo "Publishing tag: $TAG_NAME"
-
-          # Validate tag matches expected patterns
-          if ! [[ "$TAG_NAME" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "::error::Unexpected tag format '$TAG_NAME'. Expected semver (e.g. v1.0.4, 0.1.0)."
-            exit 1
-          fi
 
           ./gradlew sonatypeCentralUpload
         env:


### PR DESCRIPTION
## Summary
- Adds a `validate-tag` CI job that fails fast if a tag is pushed without the `v` prefix (e.g. `1.7.0` instead of `v1.7.0`)
- The `publish` job now depends on `validate-tag`, so bad tags never reach Maven Central
- Removes the redundant inline `v?` tag validation from the publish step since `validate-tag` now gates it

## Context
Recent releases across the SDK repos were tagged without the `v` prefix, creating inconsistency with the rest of the release history. This prevents that from happening again by gating deploys on tag format validation.

## Test plan
- [ ] Verify CI passes on this PR (compile + test jobs still run on regular pushes)
- [ ] After merge, test by creating a release with a tag like `test-no-v` and confirm the workflow fails