### PR TITLE
docs: use unified ExtendClient in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ dependencies {
 Parse any document in a few lines:
 
 ```java
-import ai.extend.wrapper.ExtendClientWrapper;
+import ai.extend.ExtendClient;
 import ai.extend.requests.ParseRequest;
 import ai.extend.types.FileFromUrl;
 import ai.extend.types.ParseRequestFile;
 import ai.extend.types.ParseRun;
 
-ExtendClientWrapper client = ExtendClientWrapper.builder()
+ExtendClient client = ExtendClient.builder()
     .apiKey("YOUR_API_KEY")
     .build();
 
@@ -299,24 +299,24 @@ The SDK defaults to the US production environment. Other regions are available:
 import ai.extend.core.Environment;
 
 // US (default)
-ExtendClientWrapper client = ExtendClientWrapper.builder()
+ExtendClient client = ExtendClient.builder()
     .apiKey("YOUR_API_KEY")
     .build();
 
 // US2 (HIPAA)
-ExtendClientWrapper client = ExtendClientWrapper.builder()
+ExtendClient client = ExtendClient.builder()
     .apiKey("YOUR_API_KEY")
     .environment(Environment.PRODUCTION_US_2)
     .build();
 
 // EU
-ExtendClientWrapper client = ExtendClientWrapper.builder()
+ExtendClient client = ExtendClient.builder()
     .apiKey("YOUR_API_KEY")
     .environment(Environment.PRODUCTION_EU_1)
     .build();
 
 // Custom base URL
-ExtendClientWrapper client = ExtendClientWrapper.builder()
+ExtendClient client = ExtendClient.builder()
     .apiKey("YOUR_API_KEY")
     .url("https://custom-api.example.com")
     .build();
@@ -334,7 +334,7 @@ The SDK automatically retries failed requests with exponential backoff. Retries 
 
 ```java
 // Configure max retries at client level
-ExtendClientWrapper client = ExtendClientWrapper.builder()
+ExtendClient client = ExtendClient.builder()
     .apiKey("YOUR_API_KEY")
     .maxRetries(1)
     .build();
@@ -348,7 +348,7 @@ The default timeout is 60 seconds. Override globally or per-request:
 import ai.extend.core.RequestOptions;
 
 // Global timeout
-ExtendClientWrapper client = ExtendClientWrapper.builder()
+ExtendClient client = ExtendClient.builder()
     .apiKey("YOUR_API_KEY")
     .timeout(30)
     .build();
@@ -362,7 +362,7 @@ client.extractRuns().create(request,
 
 ```java
 // Client-level headers
-ExtendClientWrapper client = ExtendClientWrapper.builder()
+ExtendClient client = ExtendClient.builder()
     .apiKey("YOUR_API_KEY")
     .addHeader("X-Custom-Header", "value")
     .build();
@@ -385,7 +385,7 @@ OkHttpClient customClient = new OkHttpClient.Builder()
     .connectTimeout(10, TimeUnit.SECONDS)
     .build();
 
-ExtendClientWrapper client = ExtendClientWrapper.builder()
+ExtendClient client = ExtendClient.builder()
     .apiKey("YOUR_API_KEY")
     .httpClient(customClient)
     .build();
@@ -396,9 +396,9 @@ ExtendClientWrapper client = ExtendClientWrapper.builder()
 Access underlying HTTP response metadata through `withRawResponse()`:
 
 ```java
-import ai.extend.core.ExtendClientHttpResponse;
+import ai.extend.core.ExtendClientBaseHttpResponse;
 
-ExtendClientHttpResponse<ParseRun> response = client.withRawResponse()
+ExtendClientBaseHttpResponse<ParseRun> response = client.withRawResponse()
     .parse(request);
 
 System.out.println(response.statusCode());


### PR DESCRIPTION
## Summary
Updates the README to reflect the unified client introduced in v1.15.0 (PR #55).

- All examples now construct **`ai.extend.ExtendClient`** directly instead of `ai.extend.wrapper.ExtendClientWrapper`. `ExtendClient` now carries the polling (`createAndPoll`) and webhook (`webhooks()`) helpers itself, so the wrapper is no longer needed.
- `ExtendClientWrapper` remains as a deprecated thin subclass, so existing customer code keeps working — but new code should use `ExtendClient`.
- Raw-response section: renamed `ExtendClientHttpResponse` → `ExtendClientBaseHttpResponse` (the type is derived from the generated base client name). This is the only customer-facing rename in v1.15.0 and only affects raw-response usage.

## Notes
- README is hand-maintained (protected via `.fernignore`), so these edits persist across regenerations.
- All referenced methods/types were verified against the merged SDK: `parse/extract/classify/split/edit` convenience methods are inherited from `ExtendClientBase`, and all builder setters (`apiKey`, `environment`, `url`, `maxRetries`, `timeout`, `addHeader`, `httpClient`) exist on `ExtendClient.builder()`.

## Test plan
- [ ] Visual review of README renders correctly
- [ ] Confirm examples compile against `ai.extend:extend-java-sdk:1.15.0` once published